### PR TITLE
Improve "html" type

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "remote-cms-contents",
-  "version": "0.1.1-pre.18",
+  "version": "0.1.1-pre.19",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "remote-cms-contents",
-  "version": "0.1.1-pre.19",
+  "version": "0.1.1-pre.20",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "remote-cms-contents",
-  "version": "0.1.1-pre.19",
+  "version": "0.1.1-pre.20",
   "description": "Mirror contents of remote cms to local files for nuxt-content",
   "author": "hankei6km <hankei6km@gmail.com> (https://github.com/hankei6km)",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "remote-cms-contents",
-  "version": "0.1.1-pre.18",
+  "version": "0.1.1-pre.19",
   "description": "Mirror contents of remote cms to local files for nuxt-content",
   "author": "hankei6km <hankei6km@gmail.com> (https://github.com/hankei6km)",
   "license": "MIT",

--- a/src/lib/html.ts
+++ b/src/lib/html.ts
@@ -128,10 +128,7 @@ const htmlToHtmlProcessor = (opts: HtmlToHtmlOpts) => {
       firstParagraphAsCodeDockTransformer,
       opts.frontMatter || false ? { textNode: true } : false
     )
-    .use(
-      splitParagraph,
-      opts.frontMatter || false || opts.splitParagraph || false
-    )
+    .use(splitParagraph, opts.splitParagraph || false)
     .use(rehypeStringify)
     .freeze()
 }

--- a/src/lib/html.ts
+++ b/src/lib/html.ts
@@ -1,15 +1,20 @@
-import { unified, Transformer } from 'unified'
+import { unified, Plugin, Transformer } from 'unified'
 import rehypeParse from 'rehype-parse'
 import rehype2Remark, { Options } from 'rehype-remark'
 import rehypeSanitize from 'rehype-sanitize'
 // import { Handle } from 'hast-util-to-mdast';
-import stringify from 'remark-stringify'
-import { Node, Element } from 'hast'
+import rehypeStringify from 'rehype-stringify'
+import remarkStringify from 'remark-stringify'
+import { Root, Node, Element, Text } from 'hast'
 // import visit from 'unist-util-visit';
 import splitParagraph from 'rehype-split-paragraph'
 import imageSalt from '@hankei6km/rehype-image-salt'
 import { codeDockHandler } from './codedock.js'
-import { HtmlToMarkdownOpts } from '../types/map.js'
+import {
+  MapFldsHtmlOpts,
+  HtmlToMarkdownOpts,
+  HtmlToHtmlOpts
+} from '../types/map.js'
 
 export function extractFrontMatter(
   p: Element
@@ -51,8 +56,16 @@ export function extractFrontMatter(
   return [matter, matterRange]
 }
 
+type FirstParagraphAsCodeDockTransformerOpts = { textNode: boolean }
 const fenceToFrontMatterRegExp = /^---\n(.+)\n---\n*.*$/s
-export function firstParagraphAsCodeDockTransformer(): Transformer {
+export const firstParagraphAsCodeDockTransformer: Plugin<
+  [FirstParagraphAsCodeDockTransformerOpts] | [],
+  string,
+  Root
+> = function firstParagraphAsCodeDockTransformer(
+  opts?: FirstParagraphAsCodeDockTransformerOpts
+): Transformer {
+  const { textNode } = opts || {}
   return function transformer(tree: Node): void {
     const elm = tree as Element
     if (tree.type === 'root' && Array.isArray(elm.children)) {
@@ -63,26 +76,31 @@ export function firstParagraphAsCodeDockTransformer(): Transformer {
         const cElm = elm.children[0] as Element
         const [matter, matterRange] = extractFrontMatter(cElm)
         if (matter) {
-          const matterElm: Element = {
-            type: 'element',
-            tagName: 'pre',
-            children: [
-              {
+          const matterElm: Element | Text = textNode
+            ? {
+                type: 'text',
+                value: `---\n${matter}\n---\n\n`
+              }
+            : {
                 type: 'element',
-                tagName: 'code',
+                tagName: 'pre',
                 children: [
                   {
-                    type: 'text',
-                    // value: text
-                    // ---\nfoo:bar\n--- だと qrcode 変換でつかっている
-                    // mdast-util-from-markdown で heading として扱われる。
-                    // この辺がうまくいかない場合、mdast-util-frontmattera も検討
-                    value: `===md\n---\n\n${matter}\n---\n`
+                    type: 'element',
+                    tagName: 'code',
+                    children: [
+                      {
+                        type: 'text',
+                        // value: text
+                        // ---\nfoo:bar\n--- だと qrcode 変換でつかっている
+                        // mdast-util-from-markdown で heading として扱われる。
+                        // この辺がうまくいかない場合、mdast-util-frontmattera も検討
+                        value: `===md\n---\n\n${matter}\n---\n`
+                      }
+                    ]
                   }
                 ]
               }
-            ]
-          }
           const pElm: Element = {
             ...cElm,
             children: cElm.children.slice(matterRange + 1)
@@ -101,6 +119,21 @@ export function firstParagraphAsCodeDockTransformer(): Transformer {
 const brHandler = (h: any, node: any): any => {
   // <br> が `/` になってしまうので暫定対応
   return h(node, 'text', ' ')
+}
+
+const htmlToHtmlProcessor = (opts: HtmlToHtmlOpts) => {
+  return unified()
+    .use(rehypeParse, { fragment: true })
+    .use(
+      firstParagraphAsCodeDockTransformer,
+      opts.frontMatter || false ? { textNode: true } : false
+    )
+    .use(
+      splitParagraph,
+      opts.frontMatter || false || opts.splitParagraph || false
+    )
+    .use(rehypeStringify)
+    .freeze()
 }
 
 const htmlToMarkdownProcessor = (opts: HtmlToMarkdownOpts) => {
@@ -129,11 +162,35 @@ const htmlToMarkdownProcessor = (opts: HtmlToMarkdownOpts) => {
     .use(rehype2Remark, {
       handlers: { pre: codeDockHandler, br: brHandler }
     } as unknown as Options)
-    .use(stringify)
+    .use(remarkStringify)
     .freeze()
 }
 
-export async function pageHtmlMarkdown(
+export async function htmlToHtml(
+  html: string,
+  opts: HtmlToHtmlOpts
+): Promise<string> {
+  return new Promise((resolve, reject) => {
+    if (html) {
+      htmlToHtmlProcessor(opts).process(html, function (err, file) {
+        if (err) {
+          console.error(err)
+          reject(err)
+        } else {
+          const converted = `${file}`
+          if (converted && converted[converted.length - 1] === '\n') {
+            resolve(converted)
+            return
+          }
+          resolve(`${converted}\n`)
+        }
+      })
+    }
+    resolve('')
+  })
+}
+
+export async function htmlToMarkdown(
   html: string,
   opts: HtmlToMarkdownOpts
 ): Promise<string> {
@@ -158,11 +215,17 @@ export async function pageHtmlMarkdown(
   })
 }
 
-export async function htmlToMarkdown(
+export async function htmlTo(
   html: string,
-  opts: HtmlToMarkdownOpts
+  opts: MapFldsHtmlOpts
 ): Promise<string> {
-  const md = await pageHtmlMarkdown(html, opts)
-  // return await qrcodeToDataUrl(md);
-  return md
+  let ret = ''
+  if (opts.convert === undefined || opts.convert === 'none') {
+    ret = html
+  } else if (opts.convert === 'html') {
+    ret = await htmlToHtml(html, opts.toHtmlOpts || {})
+  } else if (opts.convert === 'markdown') {
+    ret = await htmlToMarkdown(html, opts.toMarkdownOpts || {})
+  }
+  return ret
 }

--- a/src/lib/map.ts
+++ b/src/lib/map.ts
@@ -5,7 +5,7 @@ import jsonata from 'jsonata'
 import { BaseFlds, MapConfig, MapFld, MapFldsImage } from '../types/map.js'
 import { mapConfigSchema } from '../types/mapConfigSchema.js'
 import { ImageInfo } from '../types/media.js'
-import { htmlToMarkdown } from './html.js'
+import { htmlTo } from './html.js'
 
 const ajv = new Ajv()
 const validate = ajv.compile(mapConfigSchema)
@@ -218,8 +218,11 @@ export async function mappingFlds(
           break
         case 'html':
           if (srcFldType === 'string') {
-            ret[m.dstName] = await htmlToMarkdown(srcValue as string, {
-              embedImgAttrs: m.embedImgAttrs
+            const { convert, toHtmlOpts, toMarkdownOpts } = m
+            ret[m.dstName] = await htmlTo(srcValue as string, {
+              convert,
+              toHtmlOpts,
+              toMarkdownOpts
             })
           } else {
             throwInvalidType(srcFldType, m.srcName, m.dstName, m.fldType)

--- a/src/types/map.ts
+++ b/src/types/map.ts
@@ -52,6 +52,7 @@ export type MapFldsObject = {
 export type HtmlToHtmlOpts = {
   frontMatter?: boolean
   splitParagraph?: boolean
+  lfTo?: string
 }
 
 type HtmlToMarkdownOptsEmbedImgAttrs = {

--- a/src/types/map.ts
+++ b/src/types/map.ts
@@ -49,6 +49,11 @@ export type MapFldsObject = {
   fldType: 'object' // 実質 any
 } & MapFldsBase
 
+export type HtmlToHtmlOpts = {
+  frontMatter?: boolean
+  splitParagraph?: boolean
+}
+
 type HtmlToMarkdownOptsEmbedImgAttrs = {
   baseURL?: string
   embedTo?: 'alt' | 'block'
@@ -59,9 +64,16 @@ export type HtmlToMarkdownOpts = {
     | HtmlToMarkdownOptsEmbedImgAttrs
     | HtmlToMarkdownOptsEmbedImgAttrs[]
 }
+export type MapFldsHtmlOpts = {
+  convert?: 'none' | 'html' | 'markdown'
+  toHtmlOpts?: HtmlToHtmlOpts
+  toMarkdownOpts?: HtmlToMarkdownOpts
+}
 export type MapFldsHtml = {
   fldType: 'html'
-  embedImgAttrs?: HtmlToMarkdownOpts['embedImgAttrs']
+  convert?: MapFldsHtmlOpts['convert']
+  toHtmlOpts?: MapFldsHtmlOpts['toHtmlOpts']
+  toMarkdownOpts?: MapFldsHtmlOpts['toMarkdownOpts']
 } & MapFldsBase
 
 export type MapFld =

--- a/src/types/mapConfigSchema.ts
+++ b/src/types/mapConfigSchema.ts
@@ -298,59 +298,16 @@ export const mapConfigSchema =
                     {
                         "additionalProperties": false,
                         "properties": {
-                            "dstName": {
+                            "convert": {
+                                "enum": [
+                                    "html",
+                                    "markdown",
+                                    "none"
+                                ],
                                 "type": "string"
                             },
-                            "embedImgAttrs": {
-                                "anyOf": [
-                                    {
-                                        "additionalProperties": false,
-                                        "properties": {
-                                            "baseURL": {
-                                                "type": "string"
-                                            },
-                                            "embedTo": {
-                                                "enum": [
-                                                    "alt",
-                                                    "block"
-                                                ],
-                                                "type": "string"
-                                            },
-                                            "pickAttrs": {
-                                                "items": {
-                                                    "type": "string"
-                                                },
-                                                "type": "array"
-                                            }
-                                        },
-                                        "type": "object"
-                                    },
-                                    {
-                                        "items": {
-                                            "additionalProperties": false,
-                                            "properties": {
-                                                "baseURL": {
-                                                    "type": "string"
-                                                },
-                                                "embedTo": {
-                                                    "enum": [
-                                                        "alt",
-                                                        "block"
-                                                    ],
-                                                    "type": "string"
-                                                },
-                                                "pickAttrs": {
-                                                    "items": {
-                                                        "type": "string"
-                                                    },
-                                                    "type": "array"
-                                                }
-                                            },
-                                            "type": "object"
-                                        },
-                                        "type": "array"
-                                    }
-                                ]
+                            "dstName": {
+                                "type": "string"
                             },
                             "fldType": {
                                 "enum": [
@@ -363,6 +320,75 @@ export const mapConfigSchema =
                             },
                             "srcName": {
                                 "type": "string"
+                            },
+                            "toHtmlOpts": {
+                                "additionalProperties": false,
+                                "properties": {
+                                    "frontMatter": {
+                                        "type": "boolean"
+                                    },
+                                    "splitParagraph": {
+                                        "type": "boolean"
+                                    }
+                                },
+                                "type": "object"
+                            },
+                            "toMarkdownOpts": {
+                                "additionalProperties": false,
+                                "properties": {
+                                    "embedImgAttrs": {
+                                        "anyOf": [
+                                            {
+                                                "additionalProperties": false,
+                                                "properties": {
+                                                    "baseURL": {
+                                                        "type": "string"
+                                                    },
+                                                    "embedTo": {
+                                                        "enum": [
+                                                            "alt",
+                                                            "block"
+                                                        ],
+                                                        "type": "string"
+                                                    },
+                                                    "pickAttrs": {
+                                                        "items": {
+                                                            "type": "string"
+                                                        },
+                                                        "type": "array"
+                                                    }
+                                                },
+                                                "type": "object"
+                                            },
+                                            {
+                                                "items": {
+                                                    "additionalProperties": false,
+                                                    "properties": {
+                                                        "baseURL": {
+                                                            "type": "string"
+                                                        },
+                                                        "embedTo": {
+                                                            "enum": [
+                                                                "alt",
+                                                                "block"
+                                                            ],
+                                                            "type": "string"
+                                                        },
+                                                        "pickAttrs": {
+                                                            "items": {
+                                                                "type": "string"
+                                                            },
+                                                            "type": "array"
+                                                        }
+                                                    },
+                                                    "type": "object"
+                                                },
+                                                "type": "array"
+                                            }
+                                        ]
+                                    }
+                                },
+                                "type": "object"
                             }
                         },
                         "required": [

--- a/test/lib/html.spec.ts
+++ b/test/lib/html.spec.ts
@@ -137,6 +137,45 @@ describe('htmlTo() html', () => {
       '<h1>head1</h1><p>test1-1<br><br>test1-2</p><h2>head2</h2><p>test2</p>\n'
     )
   })
+  it('should replace lf', async () => {
+    expect(
+      await htmlTo(
+        '<h1>head1</h1><p>test1-1\ntest1-2</p><h2>head2</h2><p>test2-1\ntest2-2</p>',
+        {
+          convert: 'html',
+          toHtmlOpts: {}
+        }
+      )
+    ).toEqual(
+      '<h1>head1</h1><p>test1-1&#x000a;test1-2</p><h2>head2</h2><p>test2-1&#x000a;test2-2</p>\n'
+    )
+  })
+  it('should not replace lf', async () => {
+    expect(
+      await htmlTo(
+        '<h1>head1</h1><p>test1-1\ntest1-2</p><h2>head2</h2><p>test2-1\ntest2-2</p>',
+        {
+          convert: 'html',
+          toHtmlOpts: { lfTo: '' }
+        }
+      )
+    ).toEqual(
+      '<h1>head1</h1><p>test1-1\ntest1-2</p><h2>head2</h2><p>test2-1\ntest2-2</p>\n'
+    )
+  })
+  it('should replace lf without front matter', async () => {
+    expect(
+      await htmlTo(
+        '<p>---<br>title: test1<br>---<br></p><h1>head1</h1><p>test1-1\ntest1-2</p><h2>head2</h2><p>test2-1\ntest2-2</p>',
+        {
+          convert: 'html',
+          toHtmlOpts: { frontMatter: true }
+        }
+      )
+    ).toEqual(
+      '---\ntitle: test1\n\n---\n\n<h1>head1</h1><p>test1-1&#x000a;test1-2</p><h2>head2</h2><p>test2-1&#x000a;test2-2</p>\n'
+    )
+  })
 })
 
 describe('htmlTo() markdown', () => {

--- a/test/lib/html.spec.ts
+++ b/test/lib/html.spec.ts
@@ -3,7 +3,7 @@ import rehypeParse from 'rehype-parse'
 import stringify from 'rehype-stringify'
 import {
   firstParagraphAsCodeDockTransformer,
-  htmlToMarkdown
+  htmlTo
 } from '../../src/lib/html.js'
 
 describe('firstParagraphAsCodeDockTransformer()', () => {
@@ -63,31 +63,115 @@ describe('firstParagraphAsCodeDockTransformer()', () => {
   })
 })
 
-describe('htmlToMarkdown()', () => {
-  it('should convert html to markdown', async () => {
-    expect(await htmlToMarkdown('<p>test1</p>', {})).toEqual('test1\n')
+describe('htmlTo() none', () => {
+  it('should retrun html as it is', async () => {
+    expect(await htmlTo('<p>test1</p>', {})).toEqual('<p>test1</p>')
     expect(
-      await htmlToMarkdown(
-        '<h1>head1</h1><p>test1</p><h2>head2</h2><p>test2</p>',
-        {}
+      await htmlTo('<h1>head1</h1><p>test1</p><h2>head2</h2><p>test2</p>', {
+        convert: 'none'
+      })
+    ).toEqual('<h1>head1</h1><p>test1</p><h2>head2</h2><p>test2</p>')
+  })
+})
+
+describe('htmlTo() html', () => {
+  it('should convert html to html', async () => {
+    expect(await htmlTo('<p>test1</p>', { convert: 'html' })).toEqual(
+      '<p>test1</p>\n'
+    )
+    expect(
+      await htmlTo('<h1>head1</h1><p>test1</p><h2>head2</h2><p>test2</p>', {
+        convert: 'html'
+      })
+    ).toEqual('<h1>head1</h1><p>test1</p><h2>head2</h2><p>test2</p>\n')
+  })
+  it('should convert front matter', async () => {
+    expect(
+      await htmlTo(
+        '<p>---<br>title: test1<br>---<br></p><h1>head1</h1><p>test1</p><h2>head2</h2><p>test2</p>',
+        {
+          convert: 'html',
+          toHtmlOpts: { frontMatter: true }
+        }
       )
+    ).toEqual(
+      '---\ntitle: test1\n\n---\n\n<h1>head1</h1><p>test1</p><h2>head2</h2><p>test2</p>\n'
+    )
+  })
+  it('should not convert front matter', async () => {
+    expect(
+      await htmlTo(
+        '<p>---<br>title: test1<br>---<br></p><h1>head1</h1><p>test1</p><h2>head2</h2><p>test2</p>',
+        {
+          convert: 'html',
+          toHtmlOpts: {}
+        }
+      )
+    ).toEqual(
+      '<p>---<br>title: test1<br>---<br></p><h1>head1</h1><p>test1</p><h2>head2</h2><p>test2</p>\n'
+    )
+  })
+  it('should split paragraph', async () => {
+    expect(
+      await htmlTo(
+        '<h1>head1</h1><p>test1-1<br><br>test1-2</p><h2>head2</h2><p>test2</p>',
+        {
+          convert: 'html',
+          toHtmlOpts: { splitParagraph: true }
+        }
+      )
+    ).toEqual(
+      '<h1>head1</h1><p>test1-1</p><p>test1-2</p><h2>head2</h2><p>test2</p>\n'
+    )
+  })
+  it('should not split paragraph', async () => {
+    expect(
+      await htmlTo(
+        '<h1>head1</h1><p>test1-1<br><br>test1-2</p><h2>head2</h2><p>test2</p>',
+        {
+          convert: 'html',
+          toHtmlOpts: {}
+        }
+      )
+    ).toEqual(
+      '<h1>head1</h1><p>test1-1<br><br>test1-2</p><h2>head2</h2><p>test2</p>\n'
+    )
+  })
+})
+
+describe('htmlTo() markdown', () => {
+  it('should convert html to markdown', async () => {
+    expect(await htmlTo('<p>test1</p>', { convert: 'markdown' })).toEqual(
+      'test1\n'
+    )
+    expect(
+      await htmlTo('<h1>head1</h1><p>test1</p><h2>head2</h2><p>test2</p>', {
+        convert: 'markdown'
+      })
     ).toEqual('# head1\n\ntest1\n\n## head2\n\ntest2\n')
   })
   it('should convert html embed codedock to markdown', async () => {
-    expect(await htmlToMarkdown('<p>test1</p>', {})).toEqual('test1\n')
+    expect(await htmlTo('<p>test1</p>', { convert: 'markdown' })).toEqual(
+      'test1\n'
+    )
     expect(
-      await htmlToMarkdown(
+      await htmlTo(
         '<h1>head1</h1><p>test1</p><pre><code>===md\n[foo](/bar)</code></pre>',
-        {}
+        { convert: 'markdown' }
       )
     ).toEqual('# head1\n\ntest1\n\n[foo](/bar)\n')
   })
   it('should embed attrs of img to alt', async () => {
     expect(
-      await htmlToMarkdown(
+      await htmlTo(
         '<h1>head1</h1><p>test1</p><p><img src="https://localhost:3000/path/to/image.jpg" alt="image" width="300" height="200"></p><h2>head2</h2><p>test2</p>',
         {
-          embedImgAttrs: { baseURL: 'https://localhost:3000/path/to/image.jpg' }
+          convert: 'markdown',
+          toMarkdownOpts: {
+            embedImgAttrs: {
+              baseURL: 'https://localhost:3000/path/to/image.jpg'
+            }
+          }
         }
       )
     ).toEqual(
@@ -96,12 +180,15 @@ describe('htmlToMarkdown()', () => {
   })
   it('should embed attrs of img to block', async () => {
     expect(
-      await htmlToMarkdown(
+      await htmlTo(
         '<h1>head1</h1><p>test1</p><p><img src="https://localhost:3000/path/to/image.jpg" alt="image" width="300" height="200"></p><h2>head2</h2><p>test2</p>',
         {
-          embedImgAttrs: {
-            baseURL: 'https://localhost:3000/path/to/image.jpg',
-            embedTo: 'block'
+          convert: 'markdown',
+          toMarkdownOpts: {
+            embedImgAttrs: {
+              baseURL: 'https://localhost:3000/path/to/image.jpg',
+              embedTo: 'block'
+            }
           }
         }
       )
@@ -111,13 +198,16 @@ describe('htmlToMarkdown()', () => {
   })
   it('should embed custom attrs', async () => {
     expect(
-      await htmlToMarkdown(
+      await htmlTo(
         '<h1>head1</h1><p>test1</p><p><img src="https://localhost:3000/path/to/image.jpg" alt="image" width="300" height="200" data-salt-thumb></p><h2>head2</h2><p>test2</p>',
         {
-          embedImgAttrs: {
-            baseURL: 'https://localhost:3000/path/to/image.jpg',
-            embedTo: 'block',
-            pickAttrs: ['width', 'height', 'dataSaltThumb']
+          convert: 'markdown',
+          toMarkdownOpts: {
+            embedImgAttrs: {
+              baseURL: 'https://localhost:3000/path/to/image.jpg',
+              embedTo: 'block',
+              pickAttrs: ['width', 'height', 'dataSaltThumb']
+            }
           }
         }
       )
@@ -127,20 +217,23 @@ describe('htmlToMarkdown()', () => {
   })
   it('should accept opts array', async () => {
     expect(
-      await htmlToMarkdown(
+      await htmlTo(
         '<h1>head1</h1><p>test1</p><p><img src="https://localhost:3000/path/to/image.jpg" alt="image" width="300" height="200"></p><h2>head2</h2><p>test2</p><p><img src="https://localhost:3001/path/to/image.jpg" alt="image" width="300" height="200"></p>',
         {
-          embedImgAttrs: [
-            {
-              baseURL: 'https://localhost:3000/path/to/image.jpg',
-              embedTo: 'block'
-            },
-            {
-              baseURL: 'https://localhost:3001/path/to/image.jpg',
-              embedTo: 'block',
-              pickAttrs: ['width']
-            }
-          ]
+          convert: 'markdown',
+          toMarkdownOpts: {
+            embedImgAttrs: [
+              {
+                baseURL: 'https://localhost:3000/path/to/image.jpg',
+                embedTo: 'block'
+              },
+              {
+                baseURL: 'https://localhost:3001/path/to/image.jpg',
+                embedTo: 'block',
+                pickAttrs: ['width']
+              }
+            ]
+          }
         }
       )
     ).toEqual(

--- a/test/lib/map.spec.ts
+++ b/test/lib/map.spec.ts
@@ -11,7 +11,7 @@ import { MapConfig } from '../../src/types/map.js'
 describe('validateMapConfig', () => {
   test('should return MapConfig', () => {
     expect(validateMapConfig({ flds: [] })).toEqual({ flds: [] })
-    // const mapConfig: MapConfig = {
+    //const mapConfig: MapConfig = {
     const mapConfig = {
       passthruUnmapped: false,
       media: {
@@ -72,10 +72,14 @@ describe('validateMapConfig', () => {
           srcName: 'htmlFld',
           dstName: 'htmlFld',
           fldType: 'html',
-          embedImgAttrs: {
-            baseURL: '/',
-            embedTo: 'block',
-            pickAttrs: ['class']
+          convert: 'markdown',
+          toHtmlOpts: { frontMatter: false, splitParagraph: false },
+          toMarkdownOpts: {
+            embedImgAttrs: {
+              baseURL: '/',
+              embedTo: 'block',
+              pickAttrs: ['class']
+            }
           }
         }
       ]
@@ -396,7 +400,8 @@ describe('mappingFlds', () => {
             {
               srcName: '本文',
               dstName: 'content',
-              fldType: 'html'
+              fldType: 'html',
+              convert: 'markdown'
             }
           ]
         }
@@ -475,7 +480,8 @@ describe('mappingFlds', () => {
               srcName: 'content',
               dstName: 'content',
               fldType: 'html',
-              jsonata: 'html'
+              jsonata: 'html',
+              convert: 'markdown'
             }
           ]
         }


### PR DESCRIPTION
- "none" - return the html as it is
- "html" - convert to html
  - it included front matter decoded
  - multiple line break is splited paragraph
- "markdown" - convert to markdown
